### PR TITLE
Fix a bug caused by missing game-settings

### DIFF
--- a/geoguessr-training-mode.user.js
+++ b/geoguessr-training-mode.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         GeoGuessr Training Mode
 // @description  Save locations to Map Making App, toggle compass, terrain mode, hide car, and more.
-// @version      1.10
+// @version      1.10.1
 // @author       miraclewhips
 // @match        *://*.geoguessr.com/*
 // @run-at       document-start
@@ -808,6 +808,15 @@ let shouldAddSettingsButtonToSummary = false;
 
 GeoGuessrEventFramework.init().then(GEF => {
 	console.log('GeoGuessr Training Mode initialised.');
+
+	// Check and initialize game-settings if missing
+    if (!window.localStorage.getItem('game-settings')) {
+        const defaultGameSettings = {
+                forbidRotating: false
+        };
+        window.localStorage.setItem('game-settings', JSON.stringify(defaultGameSettings));
+        console.log("Initialized game-settings in localStorage");
+    }
 
 	document.addEventListener('keypress', (e) => {
 		if(e.ctrlKey || e.shiftKey || e.metaKey || e.altKey || document.activeElement.tagName === 'INPUT') return;


### PR DESCRIPTION
This bug can happen if you're using the Training Mode with no other scripts. Nowhere in the training mode does it actually add/initialize the game-settings. This causes the script to fail when it checks the game-settings to see if it should add the faceNorthBtn -

```
if(!JSON.parse(window.localStorage.getItem('game-settings')).forbidRotating) {
		faceNorthBtn = `<div class="mwgtm-settings-option" id="mwgtm-opt-compass-north">FACE NORTH - [ N ]</div>`;
	}
```

This likely isn't seen by experienced script users because that setting is already created or created by other scripts they use, but for anybody trying to use only the Training Mode they will have this issue.

To recreate the issue you can clear the localStorage and you'll see the settings don't get added and the hotkeys don't work.